### PR TITLE
chore(release): 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@monetaur/hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monetaur/hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A collection of useful React hooks",
   "main": "dist/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.1](https://github.com/monetaur/hooks/releases/tag/v1.0.1)